### PR TITLE
fix: Set native lib as @aar

### DIFF
--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -16,7 +16,7 @@ allprojects {
 }
 
 dependencies{
-    implementation("io.ionic.libs:ionfileviewer-android:1.0.0")
+    implementation("io.ionic.libs:ionfileviewer-android:1.0.0@aar")
 
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")


### PR DESCRIPTION
When using this plugins in OutSystems with MABS 10, we were getting a build error where the nativelib had a dependency that required compileSdk 35, but MABS 10 uses 34.

Because the native lib doesn't really need specific versions of a dependency, and to make sure the plugin works regardless of the low-code's android compileSdk, we unbundle the dependencies of the native lib by using `@aar`, which is what we usually have on other cordova plugins.