### PR TITLE
fix(ios): Opening local files without `file://`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONFileViewerLib" spec="1.0.2" />
+                <pod name="IONFileViewerLib" spec="1.0.3" />
             </pods>
         </podspec>
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONFileViewerLib" spec="1.0.1" />
+                <pod name="IONFileViewerLib" spec="1.0.2" />
             </pods>
         </podspec>
     


### PR DESCRIPTION
## PR Description

Fix implemented via native library v1.0.2/1.0.3 - See https://github.com/ionic-team/ion-ios-fileviewer/pull/6 for more information

## Testing

You may use O11 "File Sample App" to confirm that File Viewer functionalities are still working - the bug fixed in this PR was not reproducible on that sample app. Either the latest version or one of these:

1. [MABS 10](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=fb71f40283022152153656802b1687c0ad1fde3e&stg=dev)
2. [MABS 11.1](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=6179415e06e7eaa4a4a5d9de4dcb87677812a973&stg=dev)
3. [MABS 11.2](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=35043e8cf575283eb73785eecaa5973e62b60680&stg=dev)