### PR TITLE
refactor: Remove Synapse usage and use Capacitor Plugin Bundler

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
+++ b/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
@@ -12,12 +12,7 @@ declare class OSFileViewerWrapper {
      * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
      */
     private isCapacitorShell;
-    /**
-     * Check that is required because MABS 12 isnt installing synapse dependency for capacitor plugins.
-     * Once MABS 12 no longer has that limitation, this can be removed.
-     * @returns true if synapse is defined, false otherwise
-     */
-    private isSynapseDefined;
+    private isCordovaPluginDefined;
 }
 export declare const Instance: OSFileViewerWrapper;
 export {};

--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -5,7 +5,7 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
   }
   openDocumentFromResources(options, success, error) {
@@ -16,21 +16,21 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
   }
   previewMediaContentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
   }
   previewMediaContentFromResources(options, success, error) {
@@ -41,14 +41,14 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
   }
   checkValidResourcePath(path, error) {

--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -2,8 +2,8 @@
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 class OSFileViewerWrapper {
   openDocumentFromLocalPath(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromLocalPath(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
@@ -13,22 +13,22 @@ class OSFileViewerWrapper {
       return;
     }
     options.path = this.mapResourcePath(options.path);
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromResources(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromUrl(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
   }
   previewMediaContentFromLocalPath(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
@@ -38,15 +38,15 @@ class OSFileViewerWrapper {
       return;
     }
     options.path = this.mapResourcePath(options.path);
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromResources(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromUrl(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
@@ -80,13 +80,8 @@ class OSFileViewerWrapper {
   isCapacitorShell() {
     return typeof Capacitor !== "undefined";
   }
-  /**
-   * Check that is required because MABS 12 isnt installing synapse dependency for capacitor plugins.
-   * Once MABS 12 no longer has that limitation, this can be removed.
-   * @returns true if synapse is defined, false otherwise
-   */
-  isSynapseDefined() {
-    return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.FileViewer !== "undefined";
+  isCordovaPluginDefined() {
+    return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
   }
 }
 const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -4,8 +4,8 @@
   "use strict";
   class OSFileViewerWrapper {
     openDocumentFromLocalPath(options, success, error) {
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.openDocumentFromLocalPath(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
       }
@@ -15,22 +15,22 @@
         return;
       }
       options.path = this.mapResourcePath(options.path);
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.openDocumentFromResources(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
       }
     }
     openDocumentFromUrl(options, success, error) {
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.openDocumentFromUrl(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
       }
     }
     previewMediaContentFromLocalPath(options, success, error) {
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
       }
@@ -40,15 +40,15 @@
         return;
       }
       options.path = this.mapResourcePath(options.path);
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.previewMediaContentFromResources(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
       }
     }
     previewMediaContentFromUrl(options, success, error) {
-      if (this.isSynapseDefined()) {
-        CapacitorUtils.Synapse.FileViewer.previewMediaContentFromUrl(options, success, error);
+      if (this.isCordovaPluginDefined()) {
+        cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
       } else {
         Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
       }
@@ -82,13 +82,8 @@
     isCapacitorShell() {
       return typeof Capacitor !== "undefined";
     }
-    /**
-     * Check that is required because MABS 12 isnt installing synapse dependency for capacitor plugins.
-     * Once MABS 12 no longer has that limitation, this can be removed.
-     * @returns true if synapse is defined, false otherwise
-     */
-    isSynapseDefined() {
-      return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.FileViewer !== "undefined";
+    isCordovaPluginDefined() {
+      return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
     }
   }
   const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -7,7 +7,7 @@
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
       }
     }
     openDocumentFromResources(options, success, error) {
@@ -18,21 +18,21 @@
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
       }
     }
     openDocumentFromUrl(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
       }
     }
     previewMediaContentFromLocalPath(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
       }
     }
     previewMediaContentFromResources(options, success, error) {
@@ -43,14 +43,14 @@
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
       }
     }
     previewMediaContentFromUrl(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
       } else {
-        Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
+        window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
       }
     }
     checkValidResourcePath(path, error) {

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -1,7 +1,7 @@
 class OSFileViewerWrapper {
   openDocumentFromLocalPath(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromLocalPath(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
@@ -11,22 +11,22 @@ class OSFileViewerWrapper {
       return;
     }
     options.path = this.mapResourcePath(options.path);
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromResources(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.openDocumentFromUrl(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
   }
   previewMediaContentFromLocalPath(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
@@ -36,15 +36,15 @@ class OSFileViewerWrapper {
       return;
     }
     options.path = this.mapResourcePath(options.path);
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromResources(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
-    if (this.isSynapseDefined()) {
-      CapacitorUtils.Synapse.FileViewer.previewMediaContentFromUrl(options, success, error);
+    if (this.isCordovaPluginDefined()) {
+      cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
     } else {
       Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
@@ -78,13 +78,8 @@ class OSFileViewerWrapper {
   isCapacitorShell() {
     return typeof Capacitor !== "undefined";
   }
-  /**
-   * Check that is required because MABS 12 isnt installing synapse dependency for capacitor plugins.
-   * Once MABS 12 no longer has that limitation, this can be removed.
-   * @returns true if synapse is defined, false otherwise
-   */
-  isSynapseDefined() {
-    return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.FileViewer !== "undefined";
+  isCordovaPluginDefined() {
+    return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
   }
 }
 const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -3,7 +3,7 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
   }
   openDocumentFromResources(options, success, error) {
@@ -14,21 +14,21 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
   }
   previewMediaContentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
   }
   previewMediaContentFromResources(options, success, error) {
@@ -39,14 +39,14 @@ class OSFileViewerWrapper {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
     } else {
-      Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
+      window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
   }
   checkValidResourcePath(path, error) {

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -3,9 +3,9 @@ import { OpenFromLocalPathOptions, OpenFromResourcesOptions, OpenFromUrlOptions,
 class OSFileViewerWrapper {
 
     openDocumentFromLocalPath(options: OpenFromLocalPathOptions, success: () => void, error: (error: PluginError) => void): void {
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.openDocumentFromLocalPath(options, success, error)
+            cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options)
@@ -20,9 +20,9 @@ class OSFileViewerWrapper {
         }
         options.path = this.mapResourcePath(options.path)
 
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.openDocumentFromResources(options, success, error)
+            cordova.plugins.FileViewer.openDocumentFromResources(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.openDocumentFromResources(options)
@@ -32,9 +32,9 @@ class OSFileViewerWrapper {
     }
     
     openDocumentFromUrl(options: OpenFromUrlOptions, success: () => void, error: (error: PluginError) => void): void {
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.openDocumentFromUrl(options, success, error)
+            cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.openDocumentFromUrl(options)
@@ -44,9 +44,9 @@ class OSFileViewerWrapper {
     }
     
     previewMediaContentFromLocalPath(options: PreviewMediaFromLocalPathOptions, success: () => void, error: (error: PluginError) => void): void {
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.previewMediaContentFromLocalPath(options, success, error)
+            cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options)
@@ -61,9 +61,9 @@ class OSFileViewerWrapper {
         }
         options.path = this.mapResourcePath(options.path)
 
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.previewMediaContentFromResources(options, success, error)
+            cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options)
@@ -73,9 +73,9 @@ class OSFileViewerWrapper {
     }
     
     previewMediaContentFromUrl(options: PreviewMediaFromUrlOptions, success: () => void, error: (error: PluginError) => void): void {
-        if (this.isSynapseDefined()) {
+        if (this.isCordovaPluginDefined()) {
             // @ts-ignore
-            CapacitorUtils.Synapse.FileViewer.previewMediaContentFromUrl(options, success, error)
+            cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error)
         } else {
             // @ts-ignore
             Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options)
@@ -120,14 +120,9 @@ class OSFileViewerWrapper {
         return typeof (Capacitor) !== "undefined"
     }
 
-    /**
-     * Check that is required because MABS 12 isnt installing synapse dependency for capacitor plugins.
-     * Once MABS 12 no longer has that limitation, this can be removed.
-     * @returns true if synapse is defined, false otherwise
-     */
-    private isSynapseDefined(): boolean {
+    private isCordovaPluginDefined(): boolean {
         // @ts-ignore
-        return typeof (CapacitorUtils) !== "undefined" && typeof (CapacitorUtils.Synapse) !== "undefined" && typeof (CapacitorUtils.Synapse.FileViewer) !== "undefined"
+        return typeof(cordova) !== "undefined" && typeof(cordova.plugins) !== "undefined" && typeof(cordova.plugins.FileViewer) !== "undefined";
     }
 }
 

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -8,7 +8,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.openDocumentFromLocalPath(options)
+            window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options)
                 .then(success)
                 .catch(error);
         }
@@ -25,7 +25,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.openDocumentFromResources(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.openDocumentFromResources(options)
+            window.CapacitorPlugins.FileViewer.openDocumentFromResources(options)
                 .then(success)
                 .catch(error);
         }
@@ -37,7 +37,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.openDocumentFromUrl(options)
+            window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options)
                 .then(success)
                 .catch(error);
         }
@@ -49,7 +49,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.previewMediaContentFromLocalPath(options)
+            window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options)
                 .then(success)
                 .catch(error);
         }
@@ -66,7 +66,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.previewMediaContentFromResources(options)
+            window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options)
                 .then(success)
                 .catch(error);
         }
@@ -78,7 +78,7 @@ class OSFileViewerWrapper {
             cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error)
         } else {
             // @ts-ignore
-            Capacitor.Plugins.FileViewer.previewMediaContentFromUrl(options)
+            window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options)
                 .then(success)
                 .catch(error);
         }


### PR DESCRIPTION
## Description

This PR does some non-functional changes to the OutSystems wrapper:

1. Stop using `CapacitorUtils.Synapse`, and instead call the Capacitor / Cordova Plugin explicitly. In the (not-so close) future we will remove the `@capacitor/synapse` dependency as well - but not in this PR.
2. Replace calls of `Capacitor.Plugins.(...)` with the OutSystems Capacitor Plugin Bundler `window.CapacitorPlugins.(...)`, since it is how the OutSystems docs suggest to call the plugin.

Since the changes are just in the OutSystems wrapper, there is no need to release the Cordova Plugin.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4816

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests

You may use the File Sample app in ODC to test that everything still works across Android, iOS, and PWA.
