### PR TITLE
chore(android): remove unused dependencies to `oscore` and `oscordova`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3]
+
+### 13-01-2026
+
+- Chore(android): Remove unused dependencies to `oscore` and `oscordova`.
+
 ## [1.0.2]
 
 ### 2025-05-29

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.fileviewer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -18,9 +18,6 @@ allprojects {
 dependencies{
     implementation("io.ionic.libs:ionfileviewer-android:1.0.1@aar")
 
-    implementation("com.github.outsystems:oscore-android:1.2.0@aar")
-    implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.fileviewer" version="1.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.fileviewer" version="1.0.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFileViewerPlugin</name>
     <description>OutSystems' cordova file viewer plugin for mobile apps.</description>
     <author>OutSystems Inc</author>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Remove unused dependencies to `oscore` and `oscordova` libs

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4900

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

[MABS build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=0868ef650089c63e7c9b1fffde930da884aba52b&stg=dev)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
