### PR TITLE
chore: fix changelog and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.3]
+## [1.0.4]
 
 ### 13-01-2026
 
 - Chore(android): Remove unused dependencies to `oscore` and `oscordova`.
+
+## [1.0.3]
+
+### 09-12-2025
+
+- Fix(ios): Opening local files without file://
 
 ## [1.0.2]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.fileviewer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.fileviewer" version="1.0.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.fileviewer" version="1.0.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFileViewerPlugin</name>
     <description>OutSystems' cordova file viewer plugin for mobile apps.</description>
     <author>OutSystems Inc</author>


### PR DESCRIPTION
We had created tag 1.0.3 in December but didn't update the changelog, plugin.xml, or package.json. This fixes that.