### PR TITLE
fix(outsystems-wrapper): Allow legacy clobber in new methods

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
+++ b/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
@@ -9,10 +9,23 @@ declare class OSFileViewerWrapper {
     private checkValidResourcePath;
     private mapResourcePath;
     /**
+     * splits a validated "resources/..." path into the fileName/fileExtension pair
+     * expected by the old plugin's (pre-1.0.0 of this package) native resources API,
+     * which resolves the www/resources location itself instead of taking a full path
+     */
+    private splitResourcePath;
+    /**
      * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
      */
     private isCapacitorShell;
     private isCordovaPluginDefined;
+    /**
+     * @returns true if the native side is still running the old cordova-outsystems-fileviewer
+     * plugin (global `cordova.plugins.OSFileViewer`), e.g. after an OTA update ships this newer
+     * web wrapper on top of an app built with the previous native plugin
+     */
+    private isOldCordovaPluginDefined;
+    private isOldAndroidPlatform;
 }
 export declare const Instance: OSFileViewerWrapper;
 export {};

--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -4,6 +4,8 @@ class OSFileViewerWrapper {
   openDocumentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.openDocumentFromLocalPath(options.path, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
@@ -12,16 +14,22 @@ class OSFileViewerWrapper {
     if (!this.checkValidResourcePath(options.path, error)) {
       return;
     }
-    options.path = this.mapResourcePath(options.path);
     if (this.isCordovaPluginDefined()) {
+      options.path = this.mapResourcePath(options.path);
       cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      const { fileName, fileExtension } = this.splitResourcePath(options.path);
+      cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
     } else {
+      options.path = this.mapResourcePath(options.path);
       window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.openDocumentFromUrl(options.url, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
@@ -29,6 +37,8 @@ class OSFileViewerWrapper {
   previewMediaContentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.previewMediaContentFromLocalPath(options.path, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
@@ -37,16 +47,26 @@ class OSFileViewerWrapper {
     if (!this.checkValidResourcePath(options.path, error)) {
       return;
     }
-    options.path = this.mapResourcePath(options.path);
     if (this.isCordovaPluginDefined()) {
+      options.path = this.mapResourcePath(options.path);
       cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      const { fileName, fileExtension } = this.splitResourcePath(options.path);
+      if (this.isOldAndroidPlatform()) {
+        cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
+      } else {
+        cordova.plugins.OSFileViewer.previewMediaContentFromResources(fileName, fileExtension, success, error);
+      }
     } else {
+      options.path = this.mapResourcePath(options.path);
       window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.previewMediaContentFromUrl(options.url, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
@@ -75,6 +95,22 @@ class OSFileViewerWrapper {
     return mappedPath;
   }
   /**
+   * splits a validated "resources/..." path into the fileName/fileExtension pair
+   * expected by the old plugin's (pre-1.0.0 of this package) native resources API,
+   * which resolves the www/resources location itself instead of taking a full path
+   */
+  splitResourcePath(path) {
+    const relativePath = path.replace(/^resources\//, "");
+    const lastDotIndex = relativePath.lastIndexOf(".");
+    if (lastDotIndex === -1) {
+      return { fileName: relativePath, fileExtension: "" };
+    }
+    return {
+      fileName: relativePath.substring(0, lastDotIndex),
+      fileExtension: relativePath.substring(lastDotIndex + 1)
+    };
+  }
+  /**
    * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
    */
   isCapacitorShell() {
@@ -82,6 +118,17 @@ class OSFileViewerWrapper {
   }
   isCordovaPluginDefined() {
     return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
+  }
+  /**
+   * @returns true if the native side is still running the old cordova-outsystems-fileviewer
+   * plugin (global `cordova.plugins.OSFileViewer`), e.g. after an OTA update ships this newer
+   * web wrapper on top of an app built with the previous native plugin
+   */
+  isOldCordovaPluginDefined() {
+    return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.OSFileViewer !== "undefined";
+  }
+  isOldAndroidPlatform() {
+    return typeof cordova !== "undefined" && cordova.platformId === "android";
   }
 }
 const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -6,6 +6,8 @@
     openDocumentFromLocalPath(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        cordova.plugins.OSFileViewer.openDocumentFromLocalPath(options.path, success, error);
       } else {
         window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
       }
@@ -14,16 +16,22 @@
       if (!this.checkValidResourcePath(options.path, error)) {
         return;
       }
-      options.path = this.mapResourcePath(options.path);
       if (this.isCordovaPluginDefined()) {
+        options.path = this.mapResourcePath(options.path);
         cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        const { fileName, fileExtension } = this.splitResourcePath(options.path);
+        cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
       } else {
+        options.path = this.mapResourcePath(options.path);
         window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
       }
     }
     openDocumentFromUrl(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        cordova.plugins.OSFileViewer.openDocumentFromUrl(options.url, success, error);
       } else {
         window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
       }
@@ -31,6 +39,8 @@
     previewMediaContentFromLocalPath(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        cordova.plugins.OSFileViewer.previewMediaContentFromLocalPath(options.path, success, error);
       } else {
         window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
       }
@@ -39,16 +49,26 @@
       if (!this.checkValidResourcePath(options.path, error)) {
         return;
       }
-      options.path = this.mapResourcePath(options.path);
       if (this.isCordovaPluginDefined()) {
+        options.path = this.mapResourcePath(options.path);
         cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        const { fileName, fileExtension } = this.splitResourcePath(options.path);
+        if (this.isOldAndroidPlatform()) {
+          cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
+        } else {
+          cordova.plugins.OSFileViewer.previewMediaContentFromResources(fileName, fileExtension, success, error);
+        }
       } else {
+        options.path = this.mapResourcePath(options.path);
         window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
       }
     }
     previewMediaContentFromUrl(options, success, error) {
       if (this.isCordovaPluginDefined()) {
         cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
+      } else if (this.isOldCordovaPluginDefined()) {
+        cordova.plugins.OSFileViewer.previewMediaContentFromUrl(options.url, success, error);
       } else {
         window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
       }
@@ -77,6 +97,22 @@
       return mappedPath;
     }
     /**
+     * splits a validated "resources/..." path into the fileName/fileExtension pair
+     * expected by the old plugin's (pre-1.0.0 of this package) native resources API,
+     * which resolves the www/resources location itself instead of taking a full path
+     */
+    splitResourcePath(path) {
+      const relativePath = path.replace(/^resources\//, "");
+      const lastDotIndex = relativePath.lastIndexOf(".");
+      if (lastDotIndex === -1) {
+        return { fileName: relativePath, fileExtension: "" };
+      }
+      return {
+        fileName: relativePath.substring(0, lastDotIndex),
+        fileExtension: relativePath.substring(lastDotIndex + 1)
+      };
+    }
+    /**
      * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
      */
     isCapacitorShell() {
@@ -84,6 +120,17 @@
     }
     isCordovaPluginDefined() {
       return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
+    }
+    /**
+     * @returns true if the native side is still running the old cordova-outsystems-fileviewer
+     * plugin (global `cordova.plugins.OSFileViewer`), e.g. after an OTA update ships this newer
+     * web wrapper on top of an app built with the previous native plugin
+     */
+    isOldCordovaPluginDefined() {
+      return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.OSFileViewer !== "undefined";
+    }
+    isOldAndroidPlatform() {
+      return typeof cordova !== "undefined" && cordova.platformId === "android";
     }
   }
   const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -2,6 +2,8 @@ class OSFileViewerWrapper {
   openDocumentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.openDocumentFromLocalPath(options.path, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options).then(success).catch(error);
     }
@@ -10,16 +12,22 @@ class OSFileViewerWrapper {
     if (!this.checkValidResourcePath(options.path, error)) {
       return;
     }
-    options.path = this.mapResourcePath(options.path);
     if (this.isCordovaPluginDefined()) {
+      options.path = this.mapResourcePath(options.path);
       cordova.plugins.FileViewer.openDocumentFromResources(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      const { fileName, fileExtension } = this.splitResourcePath(options.path);
+      cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
     } else {
+      options.path = this.mapResourcePath(options.path);
       window.CapacitorPlugins.FileViewer.openDocumentFromResources(options).then(success).catch(error);
     }
   }
   openDocumentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.openDocumentFromUrl(options.url, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options).then(success).catch(error);
     }
@@ -27,6 +35,8 @@ class OSFileViewerWrapper {
   previewMediaContentFromLocalPath(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.previewMediaContentFromLocalPath(options.path, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options).then(success).catch(error);
     }
@@ -35,16 +45,26 @@ class OSFileViewerWrapper {
     if (!this.checkValidResourcePath(options.path, error)) {
       return;
     }
-    options.path = this.mapResourcePath(options.path);
     if (this.isCordovaPluginDefined()) {
+      options.path = this.mapResourcePath(options.path);
       cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      const { fileName, fileExtension } = this.splitResourcePath(options.path);
+      if (this.isOldAndroidPlatform()) {
+        cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error);
+      } else {
+        cordova.plugins.OSFileViewer.previewMediaContentFromResources(fileName, fileExtension, success, error);
+      }
     } else {
+      options.path = this.mapResourcePath(options.path);
       window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options).then(success).catch(error);
     }
   }
   previewMediaContentFromUrl(options, success, error) {
     if (this.isCordovaPluginDefined()) {
       cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error);
+    } else if (this.isOldCordovaPluginDefined()) {
+      cordova.plugins.OSFileViewer.previewMediaContentFromUrl(options.url, success, error);
     } else {
       window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options).then(success).catch(error);
     }
@@ -73,6 +93,22 @@ class OSFileViewerWrapper {
     return mappedPath;
   }
   /**
+   * splits a validated "resources/..." path into the fileName/fileExtension pair
+   * expected by the old plugin's (pre-1.0.0 of this package) native resources API,
+   * which resolves the www/resources location itself instead of taking a full path
+   */
+  splitResourcePath(path) {
+    const relativePath = path.replace(/^resources\//, "");
+    const lastDotIndex = relativePath.lastIndexOf(".");
+    if (lastDotIndex === -1) {
+      return { fileName: relativePath, fileExtension: "" };
+    }
+    return {
+      fileName: relativePath.substring(0, lastDotIndex),
+      fileExtension: relativePath.substring(lastDotIndex + 1)
+    };
+  }
+  /**
    * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
    */
   isCapacitorShell() {
@@ -80,6 +116,17 @@ class OSFileViewerWrapper {
   }
   isCordovaPluginDefined() {
     return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.FileViewer !== "undefined";
+  }
+  /**
+   * @returns true if the native side is still running the old cordova-outsystems-fileviewer
+   * plugin (global `cordova.plugins.OSFileViewer`), e.g. after an OTA update ships this newer
+   * web wrapper on top of an app built with the previous native plugin
+   */
+  isOldCordovaPluginDefined() {
+    return typeof cordova !== "undefined" && typeof cordova.plugins !== "undefined" && typeof cordova.plugins.OSFileViewer !== "undefined";
+  }
+  isOldAndroidPlatform() {
+    return typeof cordova !== "undefined" && cordova.platformId === "android";
   }
 }
 const Instance = new OSFileViewerWrapper();

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -6,6 +6,9 @@ class OSFileViewerWrapper {
         if (this.isCordovaPluginDefined()) {
             // @ts-ignore
             cordova.plugins.FileViewer.openDocumentFromLocalPath(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            // @ts-ignore
+            cordova.plugins.OSFileViewer.openDocumentFromLocalPath(options.path, success, error)
         } else {
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.openDocumentFromLocalPath(options)
@@ -13,28 +16,36 @@ class OSFileViewerWrapper {
                 .catch(error);
         }
     }
-      
+
     openDocumentFromResources(options: OpenFromResourcesOptions, success: () => void, error: (error: PluginError) => void): void {
         if (!this.checkValidResourcePath(options.path, error)) {
             return
         }
-        options.path = this.mapResourcePath(options.path)
 
         if (this.isCordovaPluginDefined()) {
+            options.path = this.mapResourcePath(options.path)
             // @ts-ignore
             cordova.plugins.FileViewer.openDocumentFromResources(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            const { fileName, fileExtension } = this.splitResourcePath(options.path)
+            // @ts-ignore
+            cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error)
         } else {
+            options.path = this.mapResourcePath(options.path)
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.openDocumentFromResources(options)
                 .then(success)
                 .catch(error);
         }
     }
-    
+
     openDocumentFromUrl(options: OpenFromUrlOptions, success: () => void, error: (error: PluginError) => void): void {
         if (this.isCordovaPluginDefined()) {
             // @ts-ignore
             cordova.plugins.FileViewer.openDocumentFromUrl(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            // @ts-ignore
+            cordova.plugins.OSFileViewer.openDocumentFromUrl(options.url, success, error)
         } else {
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.openDocumentFromUrl(options)
@@ -42,11 +53,14 @@ class OSFileViewerWrapper {
                 .catch(error);
         }
     }
-    
+
     previewMediaContentFromLocalPath(options: PreviewMediaFromLocalPathOptions, success: () => void, error: (error: PluginError) => void): void {
         if (this.isCordovaPluginDefined()) {
             // @ts-ignore
             cordova.plugins.FileViewer.previewMediaContentFromLocalPath(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            // @ts-ignore
+            cordova.plugins.OSFileViewer.previewMediaContentFromLocalPath(options.path, success, error)
         } else {
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.previewMediaContentFromLocalPath(options)
@@ -54,28 +68,45 @@ class OSFileViewerWrapper {
                 .catch(error);
         }
     }
-    
+
     previewMediaContentFromResources(options: PreviewMediaFromResourcesOptions, success: () => void, error: (error: PluginError) => void): void {
         if (!this.checkValidResourcePath(options.path, error)) {
             return
         }
-        options.path = this.mapResourcePath(options.path)
 
         if (this.isCordovaPluginDefined()) {
+            options.path = this.mapResourcePath(options.path)
             // @ts-ignore
             cordova.plugins.FileViewer.previewMediaContentFromResources(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            const { fileName, fileExtension } = this.splitResourcePath(options.path)
+            if (this.isOldAndroidPlatform()) {
+                // the old plugin's previewMediaContentFromResources is an unimplemented
+                // stub on Android (never resolves or rejects) - redirect to the open
+                // action, matching the preview-equals-open behavior both plugins already
+                // use for media-from-resources on Android
+                // @ts-ignore
+                cordova.plugins.OSFileViewer.openDocumentFromResources(fileName, fileExtension, success, error)
+            } else {
+                // @ts-ignore
+                cordova.plugins.OSFileViewer.previewMediaContentFromResources(fileName, fileExtension, success, error)
+            }
         } else {
+            options.path = this.mapResourcePath(options.path)
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.previewMediaContentFromResources(options)
                 .then(success)
                 .catch(error);
         }
     }
-    
+
     previewMediaContentFromUrl(options: PreviewMediaFromUrlOptions, success: () => void, error: (error: PluginError) => void): void {
         if (this.isCordovaPluginDefined()) {
             // @ts-ignore
             cordova.plugins.FileViewer.previewMediaContentFromUrl(options, success, error)
+        } else if (this.isOldCordovaPluginDefined()) {
+            // @ts-ignore
+            cordova.plugins.OSFileViewer.previewMediaContentFromUrl(options.url, success, error)
         } else {
             // @ts-ignore
             window.CapacitorPlugins.FileViewer.previewMediaContentFromUrl(options)
@@ -111,7 +142,24 @@ class OSFileViewerWrapper {
         mappedPath += path
         return mappedPath
     }
-    
+
+    /**
+     * splits a validated "resources/..." path into the fileName/fileExtension pair
+     * expected by the old plugin's (pre-1.0.0 of this package) native resources API,
+     * which resolves the www/resources location itself instead of taking a full path
+     */
+    private splitResourcePath(path: string): { fileName: string, fileExtension: string } {
+        const relativePath = path.replace(/^resources\//, '')
+        const lastDotIndex = relativePath.lastIndexOf('.')
+        if (lastDotIndex === -1) {
+            return { fileName: relativePath, fileExtension: '' }
+        }
+        return {
+            fileName: relativePath.substring(0, lastDotIndex),
+            fileExtension: relativePath.substring(lastDotIndex + 1)
+        }
+    }
+
     /**
      * @returns true if app is running in a capacitor shell (MABS 12), false otherwise (cordova)
      */
@@ -123,6 +171,21 @@ class OSFileViewerWrapper {
     private isCordovaPluginDefined(): boolean {
         // @ts-ignore
         return typeof(cordova) !== "undefined" && typeof(cordova.plugins) !== "undefined" && typeof(cordova.plugins.FileViewer) !== "undefined";
+    }
+
+    /**
+     * @returns true if the native side is still running the old cordova-outsystems-fileviewer
+     * plugin (global `cordova.plugins.OSFileViewer`), e.g. after an OTA update ships this newer
+     * web wrapper on top of an app built with the previous native plugin
+     */
+    private isOldCordovaPluginDefined(): boolean {
+        // @ts-ignore
+        return typeof(cordova) !== "undefined" && typeof(cordova.plugins) !== "undefined" && typeof(cordova.plugins.OSFileViewer) !== "undefined";
+    }
+
+    private isOldAndroidPlatform(): boolean {
+        // @ts-ignore
+        return typeof(cordova) !== "undefined" && cordova.platformId === "android";
     }
 }
 


### PR DESCRIPTION
## Description

> ⚠️ 🤖 AI-assisted development with Claude Code, with manual tests done by me.

> ℹ️ While this PR is a fix, it doesn't need a release for the Cordova Plugin (even if one is automatically made), because this code lives in the OutSystems Plugin and has been manually synced.

Improves the File Viewer plugin to work better with OTA scenarios where a native app with the old Cordova Plugin, prior to this PR, was not able to work with the new client actions available in this repo, only the deprecated ones. This is possible for this plugin because the API and inner behavior are identical, just needs some minor adjustments in the wrapper to work. 

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-5287

I shall open a similar PR for File Transfer if my testing goes well. For File Plugin I shall not because the old and new APIs differ too much for it to be possible.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [x] JavaScript

## Tests

You do not need to test if you don't want to.

But if you do want to test -> Test with this specific application that has the old cordova File Viewer Plugin installed, but with this updated OutSystems wrapper so that you may test that the non-deprecated client actions work with the old plugin (whereas they didn't before). Click "Test File Viewer Current methods" and "Test File Viewer DEPRECATED methods" to test specific file viewer functionality; to test with local files, go back to home and scroll down to "temporary files", click that and you'll be able to write local files that you can then open with File Viewer Plugin.

You must build this application from source:

- [O11 app Android](https://drive.google.com/file/d/1AYhX6OeCZwPDW8Z0E-4n9fkiPomiyKM6/view?usp=sharing)
- [O11 app iOS](https://drive.google.com/file/d/1qeX_WeSxLmqeptQCbkD8kwYwWuyuShOW/view?usp=sharing)